### PR TITLE
add optionally options with root_path

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ console.log(resolve.sync('./another-test.proto')) // will print a combined parse
 
 ## API
 
-* `resolve(path, cb)` read and resolve a schema
-* `resolve.sync(path)` sync version of `resolve`
+* `resolve(path, [options], cb)` read and resolve a schema. Optionally, you can pass the options object
+* `resolve.sync(path, [options])` sync version of `resolve`. Optionally, you can pass the options object
+
+`options` Options object can contain overridden 'root_path' for imported files. Default root_path is dirname of the file being processed.
+
 
 ## License
 

--- a/test/index.js
+++ b/test/index.js
@@ -6,8 +6,12 @@ var test = function(name, fn) {
     fn(t, schema)
   })
   tape(name+' sync', function(t) {
-    fn(t, function(name, cb) {
-      cb(null, schema.sync(name))
+    fn(t, function(name, options, cb) {
+      if(arguments.length === 2) {
+          cb = options
+          options = void(0)
+      }
+      cb(null, schema.sync(name, options))
     })
   })
 }
@@ -46,4 +50,12 @@ test('a imports b imports c', function(t, schema) {
       t.end()
     })
   })
+})
+
+test('d imports a with root path', function(t, schema) {
+    schema(__dirname+'/nested/d.proto', {root_path: __dirname}, function(err, sch) {
+        t.notOk(err, 'no err')
+        t.same(sch.messages.length, 4)
+        t.end()
+    })
 })

--- a/test/nested/d.proto
+++ b/test/nested/d.proto
@@ -1,0 +1,5 @@
+import "./a.proto";
+
+message D {
+  optional string d = 1;
+}


### PR DESCRIPTION
Another implementation of #1 with tests. Adds the ability to pass optional options object with the root_path. Root path is used for all imports as the base path.

This implementation behaves like dcodeIO/ProtoBuf.js and doesn't conflict with the original libraries for Java, C++ etc.

Use the protobuf options to pass the information about root_path as it is dealt in #1 doesn't sound like clean solution.
