### PR TITLE
namespaces imported protobufs when a package directive is present

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,29 @@ var schema = require('protocol-buffers-schema')
 var fs = require('fs')
 var path = require('path')
 
+var makeQualifiedName = function (pkgName) {
+  return function(_m) {
+    var m = JSON.parse(JSON.stringify(_m))
+
+    m.name = [pkgName, m.name].join('.')
+
+    return m
+  }
+}
+
 var merge = function(a, b) {
-  a.messages = a.messages.concat(b.messages)
-  a.enums = a.enums.concat(b.enums)
+  if (b.package) {
+    var qualify = makeQualifiedName(b.package)
+
+    a.messages = a.messages.concat(b.messages.map(qualify))
+    a.enums = a.enums.concat(b.enums.map(qualify))
+
+    return a
+  } else {
+    a.messages = a.messages.concat(b.messages)
+    a.enums = a.enums.concat(b.enums)
+  }
+
   return a
 }
 

--- a/test/a-pkg.proto
+++ b/test/a-pkg.proto
@@ -1,0 +1,7 @@
+package com.example.a;
+
+import "./b-pkg.proto";
+
+message A {
+  optional string a = 1;
+}

--- a/test/b-pkg.proto
+++ b/test/b-pkg.proto
@@ -1,0 +1,5 @@
+package com.example.b;
+
+message B {
+  optional string b = 1;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -47,3 +47,16 @@ test('a imports b imports c', function(t, schema) {
     })
   })
 })
+
+test('a-pkg imports b-pkg with fully qualified references', function(t, schema) {
+  schema(__dirname+'/a-pkg.proto', function(err, sch) {
+    t.notOk(err, 'no err')
+    t.same(sch.messages.length, 2)
+    t.ok(sch.messages.filter(function(m) {return m.name === 'com.example.b.B'}).length)
+    schema(__dirname+'/a-pkg', function(err, sch) {
+      t.notOk(err, 'no err')
+      t.same(sch.messages.length, 2)
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
When importing a protobuf that has a `package` directive present, this namespaces the imported messages and enums under the package name, per https://developers.google.com/protocol-buffers/docs/proto?hl=en#packages Previous behavior ignored the package name, which isn't correct.

This is a breaking change, so I can understand if it's not desired; however anyone that was using this module on protobufs that imported other schemas with `package` defined _should_ have seen this as broken behavior. It makes me think that it's an uncommon use-case, however we use it all over the place!

Anyhow, let me know if you have any questions or would like any changes made; for now I'll probably publish this as a namespaced package for my needs.

Thanks!